### PR TITLE
PROSE-160 apply vizog patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,87 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+.idea
+*.iml
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+### macOS template
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+### Eclipse template
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools 
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN find / | grep clamav-rest-.*.jar
 FROM centos:centos7
 
 
-MAINTAINER lokori <antti.virtanen@iki.fi>
+MAINTAINER vizog <vahid.zoghi@gmail.com>
 
 RUN yum update -y && yum install -y java-1.8.0-openjdk &&  yum install -y java-1.8.0-openjdk-devel && yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN find / | grep clamav-rest-.*.jar
 FROM centos:centos7
 
 
-MAINTAINER vizog <vahid.zoghi@gmail.com>
+MAINTAINER product-security <prose@tradeshift.com>
 
 RUN yum update -y && yum install -y java-1.8.0-openjdk &&  yum install -y java-1.8.0-openjdk-devel && yum clean all
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,11 +3,11 @@ set -m
 
 host=${CLAMD_HOST:-192.168.50.72}
 port=${CLAMD_PORT:-3310}
-filesize=${MAXSIZE:-10240MB}
-timeout=${TIMEOUT:-10000}
+timeout=${CLAMD_TIMOUT:-30000}
+max_file_size=${CLAMD_MAX_FILE_SIZE:-5000MB}
+max_request_size=${CLAMD_MAX_FILE_SIZE:-5000MB}
 
 echo "using clamd server: $host:$port"
 
 # start in background
-#java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port
-java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout
+java -Xmx256m -jar ./clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port  --clamd.timeout=$timeout --clamd.maxfilesize=$max_file_size  --clamd.maxrequestsize=$max_request_size

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,11 +3,11 @@ set -m
 
 host=${CLAMD_HOST:-192.168.50.72}
 port=${CLAMD_PORT:-3310}
+filesize=${CLAMD_MAX_FILE_SIZE:-5000MB}
 timeout=${CLAMD_TIMOUT:-30000}
-max_file_size=${CLAMD_MAX_FILE_SIZE:-5000MB}
-max_request_size=${CLAMD_MAX_FILE_SIZE:-5000MB}
 
 echo "using clamd server: $host:$port"
 
 # start in background
-java -Xmx256m -jar ./clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port  --clamd.timeout=$timeout --clamd.maxfilesize=$max_file_size  --clamd.maxrequestsize=$max_request_size
+#java -jar /var/clamav-rest/clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port
+java -Xmx256m -jar ./clamav-rest-1.0.2.jar --clamd.host=$host --clamd.port=$port --clamd.maxfilesize=$filesize --clamd.maxrequestsize=$filesize --clamd.timeout=$timeout

--- a/src/main/java/fi/solita/clamav/Application.java
+++ b/src/main/java/fi/solita/clamav/Application.java
@@ -8,7 +8,7 @@ import javax.servlet.MultipartConfigElement;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.context.embedded.MultipartConfigFactory;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +38,7 @@ public class Application {
 
   public static void main(String[] args) {
     SpringApplication app = new SpringApplication(Application.class);
-    Map<String, Object> defaults = new HashMap<String, Object>();
+    Map<String, Object> defaults = new HashMap<>();
     defaults.put("clamd.host", "192.168.50.72");
     defaults.put("clamd.port", 3310);
     defaults.put("clamd.timeout", 500);

--- a/src/main/java/fi/solita/clamav/ClamAVProxy.java
+++ b/src/main/java/fi/solita/clamav/ClamAVProxy.java
@@ -2,6 +2,9 @@ package fi.solita.clamav;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,11 +24,13 @@ public class ClamAVProxy {
   @Value("${clamd.timeout}")
   private int timeout;
 
+  private DateFormat df = new SimpleDateFormat("[yyyy-MM-dd'T'HH:mm:ss.SSS z]");
   /**
    * @return Clamd status.
    */
   @RequestMapping("/")
   public String ping() throws IOException {
+    System.out.println(df.format(new Date()) + " received ping");
     ClamAVClient a = new ClamAVClient(hostname, port, timeout);
     return "Clamd responding: " + a.ping() + "\n";
   }

--- a/src/main/java/fi/solita/clamav/ClamAVProxy.java
+++ b/src/main/java/fi/solita/clamav/ClamAVProxy.java
@@ -1,5 +1,7 @@
 package fi.solita.clamav;
 
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.DateFormat;
@@ -35,7 +37,7 @@ public class ClamAVProxy {
     return "Clamd responding: " + a.ping() + "\n";
   }
 
-  @RequestMapping(value="/file", method=RequestMethod.POST, consumes = "application/octet-stream")
+  @RequestMapping(value="/file", method=RequestMethod.POST, consumes = "application/octet-stream", produces = {TEXT_PLAIN_VALUE})
   public @ResponseBody String handleFileDirect(InputStream content) throws IOException{
     ClamAVClient a = new ClamAVClient(hostname, port, timeout);
     byte[] r = a.scan(content);

--- a/src/main/java/fi/solita/clamav/ClamAVProxy.java
+++ b/src/main/java/fi/solita/clamav/ClamAVProxy.java
@@ -1,14 +1,13 @@
 package fi.solita.clamav;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 public class ClamAVProxy {
@@ -31,17 +30,11 @@ public class ClamAVProxy {
     return "Clamd responding: " + a.ping() + "\n";
   }
 
-  /**
-   * @return Clamd scan result
-   */
-  @RequestMapping(value="/scan", method=RequestMethod.POST)
-  public @ResponseBody String handleFileUpload(@RequestParam("name") String name,
-                                               @RequestParam("file") MultipartFile file) throws IOException{
-    if (!file.isEmpty()) {
-      ClamAVClient a = new ClamAVClient(hostname, port, timeout);
-      byte[] r = a.scan(file.getInputStream());
-      return "Everything ok : " + ClamAVClient.isCleanReply(r) + "\n";
-    } else throw new IllegalArgumentException("empty file");
+  @RequestMapping(value="/file", method=RequestMethod.POST, consumes = "application/octet-stream")
+  public @ResponseBody String handleFileDirect(InputStream content) throws IOException{
+    ClamAVClient a = new ClamAVClient(hostname, port, timeout);
+    byte[] r = a.scan(content);
+    return "Everything ok : " + ClamAVClient.isCleanReply(r) + "\n";
   }
 
   /**

--- a/src/main/java/fi/solita/clamav/WebConfiguration.java
+++ b/src/main/java/fi/solita/clamav/WebConfiguration.java
@@ -1,0 +1,15 @@
+package fi.solita.clamav;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+public class WebConfiguration extends WebMvcConfigurerAdapter {
+
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+    	configurer.ignoreAcceptHeader(true);
+    }
+    
+}


### PR DESCRIPTION
Instead of forking https://github.com/solita/clamav-rest, we used to use a fork of https://github.com/vizog/clamav-rest.
Since Vizog has since left the company, we are now in an odd state of being out of date with the origin only because he's no longer here to keep it even with upstream 🙂 

So to cut him out of the loop, this new repo is the fork of the origin - https://github.com/solita/clamav-rest - and this PR applies the patch for all of Vizog's code.

This patch's contents (Vizog's commits):
- https://github.com/vizog/clamav-rest/commit/e1c84d84229e52f65dfaa907c902f9e09318466b
- https://github.com/vizog/clamav-rest/commit/2b2461a0ae38ae4eccf4dad5f77836bb3af94501
- https://github.com/vizog/clamav-rest/commit/0dc9251ebdeca7b928a16d02b8a39738c1ec1fe8