### PR TITLE
PROSE-175 Fix container name in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Clamd protocol contains command such as shutdown so exposing clamd directly to e
 # Usage
 
 `clamav-rest`, being just a proxy, relies on a running instance of [mkdockx/docker-clamav](https://hub.docker.com/r/mkodockx/docker-clamav) - a self-updating dockerized ClamAV scanner.
-To run `docker-clamav`:
+To run `docker-clamav` as `clamav-server`:
 ```
-  docker run -d --name docker-clamav -p 3310:3310 -v clamav:/var/lib/clamav mkodockx/docker-clamav
+  docker run -d --name clamav-server -p 3310:3310 -v clamav:/var/lib/clamav mkodockx/docker-clamav
 ```
 > :warning: `docker-clamav` takes up a lot of mem to download virus definitions from the [CVD](https://www.clamav.net/documents/clamav-virus-database-faq) at startup. Your memory limit on Docker Desktop should be set to at least 3GB so it runs successfully.
 
 To run a docker image of `clamav-rest`, you can use [lokori/clamav-rest](https://hub.docker.com/r/lokori/clamav-rest):
 ```
-  docker run -d --name clamav-rest -e 'CLAMD_HOST=docker-clamav' -p 8080:8080 --link docker-clamav:docker-clamav -t -i lokori/clamav-rest
+  docker run -d --name clamav-rest -e 'CLAMD_HOST=clamav-server' -p 8080:8080 --link clamav-server:clamav-server -t -i lokori/clamav-rest
 ```
 
 Or you can build the JAR. This creates a stand-alone JAR with embedded [Jetty serlet container](http://www.eclipse.org/jetty/).
@@ -54,7 +54,7 @@ By default clamd is assumed to respond in a local virtual machine. Setting it up
 
 # Testing the REST service
 
-You will need to run `docker-clamav` and a local `clamav-rest` to run the maven tests.
+You will need to run `docker-clamav` (aka `clamav-server`) and a local `clamav-rest` to run the maven tests.
 To run both instances:
 ```
   docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 services:
-  docker-clamav:
-    container_name: docker-clamav
+  clamav-server:
+    container_name: clamav-server
     image: mkodockx/docker-clamav
     ports:
       - "3310:3310"
@@ -10,10 +10,10 @@ services:
     build: . # run Dockerfile
     container_name: clamav-rest
     depends_on:
-      - docker-clamav
+      - clamav-server
     environment:
-      - CLAMD_HOST=docker-clamav
+      - CLAMD_HOST=clamav-server
     links:
-      - docker-clamav:docker-clamav
+      - clamav-server:clamav-server
     ports:
       - "8080:8080"


### PR DESCRIPTION
For some reason (unknown to me yet) the network is not found when using 'docker-clamav' as the container name
Linking works (`clamav-rest`-->`docker-clamav`) but the container failed to init:
```
ERROR: for docker-clamav  Cannot start service docker-clamav: network c47f4ac083e7f96d8f18ccd77d56bef6eb0467ba9a549538161b62bb95ef3c86 not found
```

This PR changes the container name back to `clamav-server` as it was in the original docs in [solita/clamav-rest](https://github.com/solita/clamav-rest/blob/master/.travis.yml#L10)

---

Sample run after this change:
```
Starting clamav-server ... done
Starting clamav-rest   ... done
Attaching to clamav-server, clamav-rest
clamav-server    | Thu Feb 11 17:19:19 2021 -> ClamAV update process started at Thu Feb 11 17:19:19 2021
clamav-rest      | using clamd server: clamav-server:3310
```