### PR TITLE
PROSE-215 Add catalog-info.yml for Backstage

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,22 @@
+# catalog-info.yml
+# This file contains metadata for backstage
+# Read more about available fields and annotations:
+# https://github.com/tradeshift/backstage
+#
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: clamav-rest
+  description: |
+    A REST API wrapping ClamAV
+  annotations:
+    github.com/project-slug: Tradeshift/clamav-rest # GitHub project name
+    sentry.io/project-slug: clamav-rest # Name in sentry for enabling Sentry integration
+    backstage.io/kubernetes-id: clamav-rest # Kubernetes app id, this is a Kubernetes label from the deployment of your service look for ex. app: backstage
+    # pagerduty.com/integration-key: a834115a04c748a5befc777442e209b8 # PagerDuty integration id from the service. Can be created in Pagerduty under Service Discovery -> Service name -> Integrations tab -> Add new integration. Please use the Events API v2, this might require you to chnage 'Alert and Incident Settings' on the 'Integrations tab' page.
+    sonarqube.org/project-key: clamav-rest # Name of the project in SonarQube
+
+spec:
+  type: service
+  owner: application-security
+  lifecycle: production


### PR DESCRIPTION
This project had no catalog info.
This PR adds once, following that in https://github.com/Tradeshift/tradeshift-clamav/blob/master/catalog-info.yml